### PR TITLE
adding some fixes for logging

### DIFF
--- a/common/log.py
+++ b/common/log.py
@@ -24,6 +24,7 @@ def init_logging(
     preamble="",
     script_type="extract",
     logger_name="WorkloadReplicatorLogger",
+    log_id=""
 ):
     """Initialize logging to stdio"""
     logger = logging.getLogger(logger_name)
@@ -56,6 +57,9 @@ def init_logging(
     logger.info(f"Logging to {filename}")
     logger.addHandler(fh)
     logger.info("== Initializing logfile ==")
+
+    if logger_name=="WorkloadReplicatorWorkerLogger":
+        logger.info(f"Reply_ID: {log_id}")
 
 
 def get_log_formatter():

--- a/core/replay/worker.py
+++ b/core/replay/worker.py
@@ -53,10 +53,11 @@ class ReplayWorker:
         # Logging needs to be separately initialized so that the worker can log to a separate log file
         init_logging(
             f"replay_worker-{self.process_idx}",
-            dir=f"core/logs/replay_worker_log-{self.replay_id}",
-            logger_name="WorkloadReplicatorLogger",
+            dir=f"core/logs/replay_worker_log",
+            logger_name="WorkloadReplicatorWorkerLogger",
             level=self.config.get("log_level", "INFO"),
             script_type=f"replay worker - {self.process_idx}",
+            log_id=self.replay_id
         )
 
         # map thread to stats dict


### PR DESCRIPTION
*Issue*
- logs were displayed twice
- for the worker logs, We were not leveraging the backup_count feature.

*Description of changes:*

for the second point in the issue.
Take a look at the images
This is how it is now 
<img width="553" alt="Screenshot 2023-04-03 at 12 10 28" src="https://user-images.githubusercontent.com/123671658/229614722-9c868355-7afa-4613-966a-690cb8a6dcc5.png">

creates separate files for the backup

This is how it will be after the change
Theses files will just keep overwriting. Makes the folder more tidy
<img width="601" alt="Screenshot 2023-04-03 at 12 10 38" src="https://user-images.githubusercontent.com/123671658/229614860-634070d8-ff75-4193-925d-dfe99b53b67a.png">

the replay_id will move into the log files
```
([INFO] 2023-04-03 19:06:43 MainThread Process-2): == Initializing logfile ==
([INFO] 2023-04-03 19:06:43 MainThread Process-2): Reply_ID: 2023-04-03T19:06:42.291367+00:00_ra3-redshift-cluster-testing_59ced
([DEBUG] 2023-04-03 19:06:44 0 Process-2): Establishing connection 1 of 10 at 1.772 (expected: 0.000, +1.772).  Pid: 1073815778, Connection times: 2023-01-09 15:48:15.313000+00:00 to 2023-01-09 15:48:15.872000+00:00, 0.559 sec
([DEBUG] 2023-04-03 19:07:34 1 Process-2): Establishing connection 2 of 10 at 52.496 (expected: 52.469, +0.027).  Pid: 1073799399, Connection times: 2023-01-09 15:49:07.782000+00:00 to 2023-01-09 15:49:08.678000+00:00, 0.896 sec
([ERROR] 2023-04-03 19:07:59 0 Process-2): (1) Failed to initiate connection for dev-awsuser-1073815778 ({'odbc': 'Driver=None; Server=ra3-redshift-cluster-testing.cqm7bdujbnqz.us-east-1.redshift.amazonaws.com; Database=dev; IAM=1; DbUser=awsuser; DbPassword=AaRtI0bax2Xu4fCX3Ux5rlztSSZ6Bsr/ROeETFEQJ/TbUMStk6RcDUGdiS4Km54IYFV8F2Q==; Port=5439', 'psql': {'username': 'IAM:awsuser', 'password': 'AaRtI0bax2Xu4fCX3Ux5rlztSSZ6Bsr/ROeETFEQJ/TbUMStk6RcDUGdiS4Km54IYFV8F2Q==', 'host': 'ra3-redshift-cluster-testing.cqm7bdujbnqz.us-east-1.redshift.amazonaws.com', 'port': '5439', 'database': 'dev'}, 'username': 'IAM:awsuser', 'password': '***', 'host': 'ra3-redshift-cluster-testing.cqm7bdujbnqz.us-east-1.redshift.amazonaws.com', 'port': '5439', 'database': 'dev', 'odbc_driver': None}): ('communication error', TimeoutError(60, 'Operation timed out'))
([WARNING] 2023-04-03 19:07:59 0 Process-2): Failed to connect
([DEBUG] 2023-04-03 19:07:59 0 Process-2): Context closing for pid: 1073815778
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
