### PR TITLE
Fixing bug for NoFileFound error

### DIFF
--- a/core/extract/cloudwatch_extractor.py
+++ b/core/extract/cloudwatch_extractor.py
@@ -88,30 +88,31 @@ class CloudwatchExtractor:
                         with gzip.open(f"{tempdir}/{log_type}.gz", "wt") as gzip_file:
                             gzip_file.write("\n".join(log_list))
 
-        logger.info("Parsing connection logs...")
-        with gzip.open(f"{tempdir}/connectionlog.gz", "r") as gzip_file:
-            parse_log(
-                gzip_file,
-                "connectionlog.gz",
-                connections,
-                last_connections,
-                logs,
-                databases,
-                start_time,
-                end_time,
-            )
-
-        logger.info("Parsing user activity logs...")
-        with gzip.open(f"{tempdir}/useractivitylog.gz", "r") as gzip_file:
-            parse_log(
-                gzip_file,
-                "useractivitylog.gz",
-                connections,
-                last_connections,
-                logs,
-                databases,
-                start_time,
-                end_time,
-            )
+                        if log_type == "connectionlog":
+                            logger.info("Parsing connection logs...")
+                            with gzip.open(f"{tempdir}/connectionlog.gz", "r") as gzip_file:
+                                parse_log(
+                                    gzip_file,
+                                    "connectionlog.gz",
+                                    connections,
+                                    last_connections,
+                                    logs,
+                                    databases,
+                                    start_time,
+                                    end_time,
+                                )
+                        if log_type == "useractivitylog":
+                            logger.info("Parsing user activity logs...")
+                            with gzip.open(f"{tempdir}/useractivitylog.gz", "r") as gzip_file:
+                                parse_log(
+                                    gzip_file,
+                                    "useractivitylog.gz",
+                                    connections,
+                                    last_connections,
+                                    logs,
+                                    databases,
+                                    start_time,
+                                    end_time,
+                                )
 
         return connections, logs, databases, last_connections


### PR DESCRIPTION
The two calls for parse_logs was outside the temporary directory context manager. 
The temporary directory deletes when the context manager closes.
Moved the calls inside the context manager
