### PR TITLE
Fix bug with AnalysisUI by escaping S3 URI strings

### DIFF
--- a/tools/ReplayAnalysis/api/app.py
+++ b/tools/ReplayAnalysis/api/app.py
@@ -50,11 +50,11 @@ def request_s3_data(filename):
     df = pd.DataFrame()
 
     for replay in selected_replays:
-        temp = None  # temporary df for individual replay
+        parsed = bucket_dict(replay["workload"])
         try:
             response = s3_client.get_object(
-                Bucket=replay["bucket"],
-                Key=f"analysis/{replay['replay_id']}/raw_data/{filename}",
+                Bucket=parsed.get("bucket_name"),
+                Key=f"{parsed.get('prefix')}{replay['replay_id']}/raw_data/{filename}",
             )
             temp = pd.read_csv(response.get("Body")).fillna(0)
         except Exception as e:

--- a/tools/ReplayAnalysis/api/utils.py
+++ b/tools/ReplayAnalysis/api/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import boto3
 import json
 from urllib.parse import urlparse
+import urllib
 
 import botocore
 import pandas as pd
@@ -28,7 +29,7 @@ def bucket_dict(bucket_url):
         path = f"{path}/"
     if path == "replays/":
         path = ""
-    return {"url": bucket_url, "bucket_name": bucket, "prefix": path}
+    return {"url": bucket_url, "bucket_name": bucket, "prefix": path + "analysis/"}
 
 
 def list_replays(bucket_url, session):
@@ -38,14 +39,17 @@ def list_replays(bucket_url, session):
     table = []
     bucket = bucket_dict(bucket_url)
     try:
+        print(bucket.get("prefix"))
         if not session:
             resp = client("s3").list_objects_v2(
-                Bucket=bucket.get("bucket_name"), Delimiter="/", Prefix="analysis/"
+                Bucket=bucket.get("bucket_name"), Delimiter="/", Prefix=bucket.get("prefix")
             )
+            s3_resource = boto3.resource("s3")
         else:
             resp = session.client("s3").list_objects_v2(
-                Bucket=bucket.get("bucket_name"), Delimiter="/", Prefix="analysis/"
+                Bucket=bucket.get("bucket_name"), Delimiter="/", Prefix=bucket.get("prefix")
             )
+            s3_resource = session.resource("s3")
         if resp["KeyCount"] == 0:
             print(
                 f"No replays available in S3. Please run a replay with replay analysis to access replays "

--- a/tools/ReplayAnalysis/gui/src/pages/home.js
+++ b/tools/ReplayAnalysis/gui/src/pages/home.js
@@ -31,7 +31,7 @@ export const HomePage = () => {
         if (uri !== '' && uri.startsWith('s3://')) {
             setSearching(true);
 
-            fetch(`/search?uri=${uri}`).then(response => response.json())
+            fetch(`/search?uri=${encodeURIComponent(uri)}`).then(response => response.json())
                 .then(response => {
                     if (!response.success) {
                         setValid(false)


### PR DESCRIPTION
Julia reported that when providing the S3 bucket link for the workload, AnalysisUI doesn't find the `analysis` folder if it's nested underneath other folders.

When I checked the code, we were defaulting to trying to find the analysis folder at the top level only and we fail if not. Additionally, the URI wasn't escaped leading to some characters such as `+` being dropped in the requests randomly.

Through this fix, I've escaped the URI being sent from the UI side and also provide an ability to find nested folders provided the S3 path is the folder immediately above the `analysis` folder.
