### PR TITLE
fixing a bug with the code in log_validation.py

### DIFF
--- a/core/util/log_validation.py
+++ b/core/util/log_validation.py
@@ -122,7 +122,7 @@ def get_logs_in_range(audit_objects, start_time, end_time):
     filenames = []
     for index, log in list(enumerate(audit_objects)):
         filename = log["Key"].split("/")[-1]
-        file_datetime = dateutil.parser.parse(filename.split("_")[-1][:-3]).replace(
+        file_datetime = dateutil.parser.parse(filename.split("_")[-1][:-3].replace("_", ":")).replace(
             tzinfo=datetime.timezone.utc
         )
         if start_time and file_datetime < start_time:


### PR DESCRIPTION
*Description of changes:*

Sometimes customers have log files with the naming convention with underscore(_) between 18 and 31:
`'254137219717_redshift_us-east-1_devsaba-sr-test_useractivitylog_2022-12-08T18_31.gz'`

The original convention should be like this with a colon(:) between 18 and 31
`'254137219717_redshift_us-east-1_devsaba-sr-test_useractivitylog_2022-12-08T18:31.gz'`

I am adding this change so this wont throw an error here.


