### PR TITLE
Remove unused csv

### DIFF
--- a/core/tests/test_connection_thread.py
+++ b/core/tests/test_connection_thread.py
@@ -256,33 +256,6 @@ class TestConnectionThread(unittest.TestCase):
         assert mock_exec_transaction.called_with(transactions, mock_connection)
         patched_time_sleep.assert_not_called()
 
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("core.replay.connection_thread.Path")
-    def test_save_query_stats_fp_zero(self, mock_path, open_mock):
-        conn_thread = get_connection_thread(
-            get_connection_log(get_transactions([query_1]))
-        )
-        conn_thread.perf_lock = threading.Lock()
-        mock_path.mkdir.return_value = "value"
-
-        conn_thread.save_query_stats(
-            datetime.datetime(2023, 2, 1, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            datetime.datetime(2023, 2, 1, 10, 0, 4, 0, tzinfo=datetime.timezone.utc),
-            1,
-            2,
-        )
-
-        calls = [
-            call("core/logs/replay/2023-02-01T09:45:00+00:00/1_times.csv", "a+"),
-            call().__enter__(),
-            call().tell(),
-            call().write(
-                "1,1-2,2023-02-01 10:00:00+00:00,2023-02-01 10:00:04+00:00,4.000000,0\n"
-            ),
-            call().__exit__(None, None, None),
-        ]
-
-        open_mock.assert_has_calls(calls, any_order=True)
 
     @patch("core.replay.connection_thread.open", new_callable=mock_open)
     @patch("core.replay.connection_thread.Path")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove generation of unused csvs during replay. Did a search in the codebase, and these csvs do not seem to be used in a later process.
<img width="385" alt="Screenshot 2023-08-24 at 4 32 31 PM" src="https://github.com/aws/redshift-test-drive/assets/121250701/cc8a6622-9c54-40ce-877a-5ecb2b48ba7c">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
