### PR TITLE
NodeConfig_RestoreClusterfromSnapshot_IAM_permission_bug_fix

### DIFF
--- a/tools/NodeConfigCompare/configuration/cloud_formation_template.yaml
+++ b/tools/NodeConfigCompare/configuration/cloud_formation_template.yaml
@@ -486,19 +486,7 @@ Resources:
           - Effect: Allow
             Action:
               - ec2:Describe*
-            Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:elastic-ip/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:client-vpn-endpoint/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:fleet/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:fpga-image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:snapshot/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:spot-fleet-request/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volumne/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:elastic-ip/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc-endpoint-service/*"
+            Resource: "*"
 
   RedshiftServerlessIAMPolicy:
     Type: 'AWS::IAM::ManagedPolicy'


### PR DESCRIPTION
*Description of changes:*
The issue is customer cannot create a cluster from restoring a snapshot because of some missing Resources in the IAM policy
The error that the customer gets is 
```
An error occurred (UnauthorizedOperation) when calling the RestoreFromClusterSnapshot operation: Access Denied. Please ensure that your IAM Permissions allow this operation.
```

This change in code fixes it. 
