### PR TITLE
 Region config in redshift-test-drive/main/config/extract.yaml not us…

### DIFF
--- a/tools/NodeConfigCompare/bootstrap_scripts/extract_bootstrap.sh
+++ b/tools/NodeConfigCompare/bootstrap_scripts/extract_bootstrap.sh
@@ -22,7 +22,7 @@ git clone https://github.com/aws/redshift-test-drive.git
 cd redshift-test-drive
 make setup
 if [[ "$SIMPLE_REPLAY_EXTRACT_OVERWRITE_S3_PATH" != "N/A" ]]; then
-  aws s3 cp $SIMPLE_REPLAY_EXTRACT_OVERWRITE_S3_PATH config/replay.yaml
+  aws s3 cp $SIMPLE_REPLAY_EXTRACT_OVERWRITE_S3_PATH config/extract.yaml
 fi
 WORKLOAD_LOCATION="s3://${BUCKET_NAME}/${EXTRACT_PREFIX}/${WHAT_IF_TIMESTAMP}"
 sed -i "s#master_username: \".*\"#master_username: \"$REDSHIFT_USER_NAME\"#g" config/extract.yaml


### PR DESCRIPTION
…ed #125

 The config/extract.yaml template from S3 is not used.

*Issue 127, if available:*

*Description of changes:*
The extract.yaml from S3 was not copied correctly. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
