### PR TITLE
uploading the replay worker logs to s3

### DIFF
--- a/core/replay/replay.py
+++ b/core/replay/replay.py
@@ -189,8 +189,8 @@ def main():
 
     bucket = bucket_dict(config["workload_location"])
     if bucket.get("bucket_name", ""):
+        logger.info(f"Uploading replay logs to {bucket['bucket_name']}/{bucket['prefix']}")
         for log_type, directory in [("replay_logs","core/logs/replay/replay_log"), ("replay_worker_logs","core/logs/replay_log")]:
-            logger.info(f"Uploading replay logs to {bucket['bucket_name']}/{bucket['prefix']}")
             object_key = f"{log_type}.zip"
             zip_file_name = f"{log_type}.zip"
             dir = f"{directory}-{replay_id}"

--- a/core/replay/replay.py
+++ b/core/replay/replay.py
@@ -188,10 +188,10 @@ def main():
     # uploading replay logs to s3
 
     bucket = bucket_dict(config["workload_location"])
-    object_key = "replay_logs.zip"
-    zip_file_name = f"replay_logs.zip"
     if bucket.get("bucket_name", ""):
         logger.info(f"Uploading replay logs to {bucket['bucket_name']}/{bucket['prefix']}")
+        object_key = "replay_logs.zip"
+        zip_file_name = f"replay_logs.zip"
         dir = f"core/logs/replay/replay_log-{replay_id}"
         with zipfile.ZipFile(zip_file_name, "w", zipfile.ZIP_DEFLATED) as zip_object:
             for folder_name, sub_folders, file_names in os.walk(dir):
@@ -202,6 +202,21 @@ def main():
             aws_service_helper.s3_put_object(
                 f, bucket["bucket_name"], f"{bucket['prefix']}{object_key}"
             )
+        
+        logger.info(f"Uploading replay worker logs to {bucket['bucket_name']}/{bucket['prefix']}")
+        dir = f"core/logs/replay_log-{replay_id}"
+        object_key = "replay_worker_logs.zip"
+        zip_file_name = f"replay_worker_logs.zip"
+        with zipfile.ZipFile(zip_file_name, "w", zipfile.ZIP_DEFLATED) as zip_object:
+            for folder_name, sub_folders, file_names in os.walk(dir):
+                for filename in file_names:
+                    file_path = os.path.join(folder_name, filename)
+                    zip_object.write(file_path)
+        with open(zip_file_name, "rb") as f:
+            aws_service_helper.s3_put_object(
+                f, bucket["bucket_name"], f"{bucket['prefix']}{object_key}"
+            )
+        
     else:
         logger.info("Invalid bucket name")
 

--- a/core/replay/replay.py
+++ b/core/replay/replay.py
@@ -189,33 +189,20 @@ def main():
 
     bucket = bucket_dict(config["workload_location"])
     if bucket.get("bucket_name", ""):
-        logger.info(f"Uploading replay logs to {bucket['bucket_name']}/{bucket['prefix']}")
-        object_key = "replay_logs.zip"
-        zip_file_name = f"replay_logs.zip"
-        dir = f"core/logs/replay/replay_log-{replay_id}"
-        with zipfile.ZipFile(zip_file_name, "w", zipfile.ZIP_DEFLATED) as zip_object:
-            for folder_name, sub_folders, file_names in os.walk(dir):
-                for filename in file_names:
-                    file_path = os.path.join(folder_name, filename)
-                    zip_object.write(file_path)
-        with open(zip_file_name, "rb") as f:
-            aws_service_helper.s3_put_object(
-                f, bucket["bucket_name"], f"{bucket['prefix']}{object_key}"
-            )
-        
-        logger.info(f"Uploading replay worker logs to {bucket['bucket_name']}/{bucket['prefix']}")
-        dir = f"core/logs/replay_log-{replay_id}"
-        object_key = "replay_worker_logs.zip"
-        zip_file_name = f"replay_worker_logs.zip"
-        with zipfile.ZipFile(zip_file_name, "w", zipfile.ZIP_DEFLATED) as zip_object:
-            for folder_name, sub_folders, file_names in os.walk(dir):
-                for filename in file_names:
-                    file_path = os.path.join(folder_name, filename)
-                    zip_object.write(file_path)
-        with open(zip_file_name, "rb") as f:
-            aws_service_helper.s3_put_object(
-                f, bucket["bucket_name"], f"{bucket['prefix']}{object_key}"
-            )
+        for log_type, directory in [("replay_logs","core/logs/replay/replay_log"), ("replay_worker_logs","core/logs/replay_log")]:
+            logger.info(f"Uploading replay logs to {bucket['bucket_name']}/{bucket['prefix']}")
+            object_key = f"{log_type}.zip"
+            zip_file_name = f"{log_type}.zip"
+            dir = f"{directory}-{replay_id}"
+            with zipfile.ZipFile(zip_file_name, "w", zipfile.ZIP_DEFLATED) as zip_object:
+                for folder_name, sub_folders, file_names in os.walk(dir):
+                    for filename in file_names:
+                        file_path = os.path.join(folder_name, filename)
+                        zip_object.write(file_path)
+            with open(zip_file_name, "rb") as f:
+                aws_service_helper.s3_put_object(
+                    f, bucket["bucket_name"], f"{bucket['prefix']}{object_key}"
+                )
         
     else:
         logger.info("Invalid bucket name")


### PR DESCRIPTION
*Issue #, if available:*

Currently we only upload the main thread logs to s3. When customer faces issues looking at the file does not give us a lot of information. 
I modified the code to upload the worker logs to s3 too. This will help us analyze customer issues more thoroughly.

*Description of changes:*

now along with replay_log.zip file in s3 we will also have replay_worker_log.zip ( which will have the files replay_worker-0, replay_worker-1... etc)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
