### PR TITLE
 fixing a bug in logging an extract run

### DIFF
--- a/core/extract/extract.py
+++ b/core/extract/extract.py
@@ -63,25 +63,27 @@ def main():
         sys.exit("Failed to load driver")
 
     # setting application name for tracking
-    application = "WorkloadReplicator-Extract"
-    
-    host = config.get("source_cluster_endpoint").split(".")[0]
-    port = int(config.get("source_cluster_endpoint").split(":")[-1].split("/")[0])
-    DbUser = config.get("master_username")
-    DbName = config.get("source_cluster_endpoint").split("/")[-1]
-    region = config.get("region")
-    endpoint = config.get('source_cluster_endpoint').split(":")[0]
+    if config.get("source_cluster_endpoint"):
+        application = "WorkloadReplicator-Extract"
 
-    response = aws_service_helper.redshift_get_cluster_credentials(
-        user=DbUser,
-        database_name=DbName,
-        cluster_id=host,
-        region=region)
-    db_connect(host=endpoint,
-               port=port,
-               database=DbName,
-               password=response['DbPassword'],
-               username=response['DbUser'], app_name=application)
+        host = config.get("source_cluster_endpoint").split(".")[0]
+        port = int(config.get("source_cluster_endpoint").split(":")[-1]
+                   .split("/")[0])
+        DbUser = config.get("master_username")
+        DbName = config.get("source_cluster_endpoint").split("/")[-1]
+        region = config.get("region")
+        endpoint = config.get('source_cluster_endpoint').split(":")[0]
+
+        response = aws_service_helper.redshift_get_cluster_credentials(
+            user=DbUser,
+            database_name=DbName,
+            cluster_id=host,
+            region=region)
+        db_connect(host=endpoint,
+                   port=port,
+                   database=DbName,
+                   password=response['DbPassword'],
+                   username=response['DbUser'], app_name=application)
 
     # Run extract job
     (


### PR DESCRIPTION
*Issue #, if available:*
When Cluster endpoint was not given, it breaks extract because of a recent code addition for logging.
*Description of changes:*
Added an if statement for now, to unblock the customer. 
But we should have an elaborate discussion on if we need to have this logging done for extract because when the customer does not give the cluster endpoint we wont log extract as being used. THis wont give a full picture of how many times extract was used. Also logging  Replay is more useful in my opinion than extract as customers cant do much with just the extract.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
