### PR TITLE
modifying sql by removing pg tables in the query

### DIFF
--- a/core/sql/aborted_queries.sql
+++ b/core/sql/aborted_queries.sql
@@ -1,20 +1,18 @@
-SELECT 
-q.user_id as "userid",
-TRIM(u.usename) AS usename
-,case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
-,date_trunc('hour', q.start_time) as "period"
-,q.transaction_id as "xid"
-,q.query_id as "query"
-,q.query_text::char(50) as "querytxt"
-,q.queue_time / 1000000.00 as "queue_s"
-,q.execution_time / 1000000.00 as "exec_time_s" -- This includes compile time. Differs in behavior from provisioned metric
-,case when q.status = 'failed' then 1 else 0 end "aborted"
-,q.elapsed_time / 1000000.00 as "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
+/*AbortedQueries*/
+SELECT q.user_id                                                                       as "userid"
+     , case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
+     , date_trunc('hour', q.start_time)                                                as "period"
+     , q.transaction_id                                                                as "xid"
+     , q.query_id                                                                      as "query"
+     , q.query_text::char(50)                                                          as "querytxt"
+     , q.queue_time / 1000000.00                                                       as "queue_s"
+     , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
+     , case when q.status = 'failed' then 1 else 0 end                                    "aborted"
+     , q.elapsed_time / 1000000.00                                                     as "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
 FROM sys_query_history q
-  LEFT JOIN pg_user u ON u.usesysid = q.user_id
 WHERE q.user_id > 1
-  AND   q.start_time >={{START_TIME}}
-  AND   q.start_time <={{END_TIME}}
-  AND   q.query_text LIKE '%replay_start%'
-  AND   q.status = 'failed'
+  AND q.start_time >={{START_TIME}}
+  AND q.start_time <={{END_TIME}}
+  AND q.query_text LIKE '%replay_start%'
+  AND q.status = 'failed'
 ORDER BY total_elapsed_s DESC;

--- a/core/sql/cluster_level_metrics.sql
+++ b/core/sql/cluster_level_metrics.sql
@@ -1,70 +1,70 @@
+/*ClusterLevelMetrics*/
 WITH queries AS
-(
-  select
-  q.user_id as "userid"
-  ,date_trunc('hour', q.start_time) as "period"
-  ,q.transaction_id as "xid"
-  ,q.query_id as "query"
-  ,q.query_text::char(50) as "querytxt"
-  ,q.queue_time / 1000000.00 as "queue_s"
-  ,q.execution_time / 1000000.00 as "exec_time_s" -- This includes compile time. Differs in behavior from provisioned metric
-  ,case when q.status = 'failed' then 1 else 0 end "aborted"
-  ,q.elapsed_time / 1000000.00 as "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
-  FROM sys_query_history q
-  WHERE q.user_id > 1
-  AND   q.start_time >= {{START_TIME}}
-  AND   q.start_time <= {{END_TIME}}
-  AND   q.query_text LIKE '%replay_start%'
-  AND   q.status != 'failed'
-),
-elapsed_time AS
-(
-  SELECT 'Query Latency' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p99_s,
-         MAX(total_elapsed_s) AS max_s,
-         AVG(total_elapsed_s) AS avg_s,
-         stddev(total_elapsed_s) AS std_s
-  FROM queries
-  GROUP BY 1
-),
-exec_time AS
-(
-  SELECT 'Execution Time' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY exec_time_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY exec_time_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY exec_time_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY exec_time_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY exec_time_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY exec_time_s),2) AS p99_s,
-         MAX(exec_time_s) AS max_s,
-         AVG(exec_time_s) AS avg_s,
-         stddev(exec_time_s) AS std_s
-  FROM queries
-  GROUP BY 1
-),
-queue_time AS
-(
-  SELECT 'Queue Time' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY queue_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY queue_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY queue_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY queue_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY queue_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY queue_s),2) AS p99_s,
-         MAX(queue_s) AS max_s,
-         AVG(queue_s) AS avg_s,
-         stddev(queue_s) AS std_s
-  FROM queries
-  GROUP BY 1
-)
+         (
+             select q.user_id                        as             "userid"
+                  , date_trunc('hour', q.start_time) as             "period"
+                  , q.transaction_id                 as             "xid"
+                  , q.query_id                       as             "query"
+                  , q.query_text::char(50)           as             "querytxt"
+                  , q.queue_time / 1000000.00        as             "queue_s"
+                  , q.execution_time / 1000000.00    as             "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
+                  , case when q.status = 'failed' then 1 else 0 end "aborted"
+                  , q.elapsed_time / 1000000.00      as             "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
+             FROM sys_query_history q
+             WHERE q.user_id > 1
+               AND q.start_time >= {{START_TIME}}
+               AND q.start_time <= {{END_TIME}}
+               AND q.query_text LIKE '%replay_start%'
+               AND q.status != 'failed'
+         ),
+     elapsed_time AS
+         (
+             SELECT 'Query Latency'                                                         AS measure_type,
+                    COUNT(*)                                                                AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p99_s,
+                    MAX(total_elapsed_s)                                                    AS max_s,
+                    AVG(total_elapsed_s)                                                    AS avg_s,
+                    stddev(total_elapsed_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1
+         ),
+     exec_time AS
+         (
+             SELECT 'Execution Time'                                                    AS measure_type,
+                    COUNT(*)                                                            AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p99_s,
+                    MAX(exec_time_s)                                                    AS max_s,
+                    AVG(exec_time_s)                                                    AS avg_s,
+                    stddev(exec_time_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1
+         ),
+     queue_time AS
+         (
+             SELECT 'Queue Time'                                                    AS measure_type,
+                    COUNT(*)                                                        AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY queue_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY queue_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY queue_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY queue_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY queue_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY queue_s), 2) AS p99_s,
+                    MAX(queue_s)                                                    AS max_s,
+                    AVG(queue_s)                                                    AS avg_s,
+                    stddev(queue_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1
+         )
 SELECT measure_type,
        query_count,
        p25_s,

--- a/core/sql/latency_distribution.sql
+++ b/core/sql/latency_distribution.sql
@@ -1,61 +1,62 @@
+/*LatencyDistribution*/
 WITH queries AS
-(
-  SELECT q.query_id
-        ,q.elapsed_time / 1000000.00 as total_elapsed_s
-  FROM sys_query_history q
-  WHERE q.user_id > 1
-  AND   q.start_time >= {{START_TIME}}
-  AND   q.start_time <= {{END_TIME}}
-  AND   q.query_text LIKE '%replay_start%'
-  AND   status != 'failed'
-)
-,
-pct AS
-(
-  SELECT ROUND(PERCENTILE_CONT (0.98) WITHIN GROUP(ORDER BY q1.total_elapsed_s),2) AS p98_s,
-         COUNT(*) AS query_count,
-         MAX(q1.total_elapsed_s) max_s,
-         MIN(q1.total_elapsed_s) min_s,
-         MIN(CASE WHEN q1.total_elapsed_s = 0.00 THEN NULL ELSE q1.total_elapsed_s END) min_2s
-  FROM queries q1
-),
-bucket_count AS
-(
-  SELECT CASE
-           WHEN query_count > 100 THEN 40
-           ELSE 5
-         END AS b_count
-  FROM pct
-),
-buckets AS
-(
-  SELECT (min_2s +((n)*(p98_s / b_count))) AS sec_end,
-         n,
-         (min_2s +((n -1)*(p98_s / b_count))) AS sec_start
-  FROM (SELECT ROW_NUMBER() OVER () n FROM pg_class LIMIT 39),
-       bucket_count,
-       pct
-  WHERE sec_end <= p98_s
-  UNION ALL
-  SELECT min_2s AS sec_end,
-         0 AS n,
-         0.00 AS sec_start
-  FROM pct
-  UNION ALL
-  SELECT (max_s +0.01) AS sec_end,
-         b_count AS n,
-         p98_s AS sec_start
-  FROM pct,
-       bucket_count
-)
+         (
+             SELECT q.query_id
+                  , q.elapsed_time / 1000000.00 as total_elapsed_s
+             FROM sys_query_history q
+             WHERE q.user_id > 1
+               AND q.start_time >= {{START_TIME}}
+               AND q.start_time <= {{END_TIME}}
+               AND q.query_text LIKE '%replay_start%'
+               AND status != 'failed'
+         )
+        ,
+     pct AS
+         (
+             SELECT ROUND(PERCENTILE_CONT(0.98) WITHIN GROUP (ORDER BY q1.total_elapsed_s), 2) AS  p98_s,
+                    COUNT(*)                                                                   AS  query_count,
+                    MAX(q1.total_elapsed_s)                                                        max_s,
+                    MIN(q1.total_elapsed_s)                                                        min_s,
+                    MIN(CASE WHEN q1.total_elapsed_s = 0.00 THEN NULL ELSE q1.total_elapsed_s END) min_2s
+             FROM queries q1
+         ),
+     bucket_count AS
+         (
+             SELECT CASE
+                        WHEN query_count > 100 THEN 40
+                        ELSE 5
+                        END AS b_count
+             FROM pct
+         ),
+     buckets AS
+         (
+             SELECT (min_2s + ((n) * (p98_s / b_count)))     AS sec_end,
+                    n,
+                    (min_2s + ((n - 1) * (p98_s / b_count))) AS sec_start
+             FROM (SELECT ROW_NUMBER() OVER () n FROM pg_class LIMIT 39),
+                  bucket_count,
+                  pct
+             WHERE sec_end <= p98_s
+             UNION ALL
+             SELECT min_2s AS sec_end,
+                    0      AS n,
+                    0.00   AS sec_start
+             FROM pct
+             UNION ALL
+             SELECT (max_s + 0.01) AS sec_end,
+                    b_count        AS n,
+                    p98_s          AS sec_start
+             FROM pct,
+                  bucket_count
+         )
 SELECT sec_end,
        n,
        sec_start,
        COUNT(query_id)
 FROM buckets
-  LEFT JOIN queries
-         ON total_elapsed_s >= sec_start
-        AND total_elapsed_s < sec_end
+         LEFT JOIN queries
+                   ON total_elapsed_s >= sec_start
+                       AND total_elapsed_s < sec_end
 GROUP BY 1,
          2,
          3

--- a/core/sql/query_distribution.sql
+++ b/core/sql/query_distribution.sql
@@ -1,109 +1,108 @@
+/*QueryDistribution*/
 WITH queries AS
-(
-  select
-  q.user_id as "userid",
-  TRIM(u.usename) AS usename
-  ,case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
-  ,date_trunc('hour', q.start_time) as "period"
-  ,q.transaction_id as "xid"
-  ,q.query_id as "query"
-  ,q.query_text::char(50) as "querytxt"
-  ,q.queue_time / 1000000.00 as "queue_s"
-  ,q.execution_time / 1000000.00 as "exec_time_s" -- This includes compile time. Differs in behavior from provisioned metric
-  ,case when q.status = 'failed' then 1 else 0 end "aborted"
-  ,q.elapsed_time / 1000000.00 as "total_elapsed_s" --again includes compile time
-  ,user_query_count
-  ,DENSE_RANK() OVER (ORDER BY user_query_count) AS rnk
-  FROM sys_query_history q
-  LEFT JOIN pg_user u ON u.usesysid = q.user_id
-  inner join (select user_id, count(*) user_query_count
-  from sys_query_history
-  where user_id>1
-    AND start_time >={{START_TIME}}
-    AND   start_time <={{END_TIME}}
-    AND   query_text LIKE '%replay_start%'
-    AND   status != 'failed' group by user_id) uc on uc.user_id = q.user_id
-  WHERE q.user_id > 1
-    AND   q.start_time >={{START_TIME}}
-    AND   q.start_time <={{END_TIME}}
-    AND   q.query_text LIKE '%replay_start%'
-    AND   q.status != 'failed'
-),
-elapsed_time AS
-(
-  SELECT CASE
-           WHEN rnk <= 100 THEN usename
-           ELSE 'Other Users'
-         END AS usename,
-         queue,
-         aborted,
-         'Query Latency' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY total_elapsed_s),2) AS p99_s,
-         MAX(total_elapsed_s) AS max_s,
-         AVG(total_elapsed_s) AS avg_s,
-         stddev(total_elapsed_s) AS std_s
-  FROM queries
-  GROUP BY 1,
-           2,
-           3,
-           4
-),
-exec_time AS
-(
-  SELECT CASE
-           WHEN rnk <= 100 THEN usename
-           ELSE 'Other Users'
-         END AS usename,
-         queue,
-         aborted,
-         'Execution Time' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY exec_time_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY exec_time_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY exec_time_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY exec_time_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY exec_time_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY exec_time_s),2) AS p99_s,
-         MAX(exec_time_s) AS max_s,
-         AVG(exec_time_s) AS avg_s,
-         stddev(exec_time_s) AS std_s
-  FROM queries
-  GROUP BY 1,
-           2,
-           3,
-           4
-),
-queue_time AS
-(
-  SELECT CASE
-           WHEN rnk <= 100 THEN usename
-           ELSE 'Other Users'
-         END AS usename,
-         queue,
-         aborted,
-         'Queue Time' AS measure_type,
-         COUNT(*) AS query_count,
-         ROUND(PERCENTILE_CONT (0.25) WITHIN GROUP(ORDER BY queue_s),2) AS p25_s,
-         ROUND(PERCENTILE_CONT (0.50) WITHIN GROUP(ORDER BY queue_s),2) AS p50_s,
-         ROUND(PERCENTILE_CONT (0.75) WITHIN GROUP(ORDER BY queue_s),2) AS p75_s,
-         ROUND(PERCENTILE_CONT (0.90) WITHIN GROUP(ORDER BY queue_s),2) AS p90_s,
-         ROUND(PERCENTILE_CONT (0.95) WITHIN GROUP(ORDER BY queue_s),2) AS p95_s,
-         ROUND(PERCENTILE_CONT (0.99) WITHIN GROUP(ORDER BY queue_s),2) AS p99_s,
-         MAX(queue_s) AS max_s,
-         AVG(queue_s) AS avg_s,
-         stddev(queue_s) AS std_s
-  FROM queries
-  GROUP BY 1,
-           2,
-           3,
-           4
-)
+         (
+             select q.user_id                                                                       as "userid"
+                  , case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
+                  , date_trunc('hour', q.start_time)                                                as "period"
+                  , q.transaction_id                                                                as "xid"
+                  , q.query_id                                                                      as "query"
+                  , q.query_text::char(50)                                                          as "querytxt"
+                  , q.queue_time / 1000000.00                                                       as "queue_s"
+                  , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
+                  , case when q.status = 'failed' then 1 else 0 end                                    "aborted"
+                  , q.elapsed_time / 1000000.00                                                     as "total_elapsed_s" --again includes compile time
+                  , user_query_count
+                  , DENSE_RANK() OVER (ORDER BY user_query_count)                                   AS rnk
+             FROM sys_query_history q
+                      inner join (select user_id, count(*) user_query_count
+                                  from sys_query_history
+                                  where user_id > 1
+                                    AND start_time >={{START_TIME}}
+                                    AND start_time <={{END_TIME}}
+                                    AND query_text LIKE '%replay_start%'
+                                    AND status != 'failed'
+                                  group by user_id) uc on uc.user_id = q.user_id
+             WHERE q.user_id > 1
+               AND q.start_time >={{START_TIME}}
+               AND q.start_time <={{END_TIME}}
+               AND q.query_text LIKE '%replay_start%'
+               AND q.status != 'failed'
+         ),
+     elapsed_time AS
+         (
+             SELECT CASE
+                        WHEN rnk <= 100 THEN cast(userid as char(6))
+                        ELSE 'Other Users'
+                        END                                                                 AS usename,
+                    queue,
+                    aborted,
+                    'Query Latency'                                                         AS measure_type,
+                    COUNT(*)                                                                AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p99_s,
+                    MAX(total_elapsed_s)                                                    AS max_s,
+                    AVG(total_elapsed_s)                                                    AS avg_s,
+                    stddev(total_elapsed_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1,
+                      2,
+                      3,
+                      4
+         ),
+     exec_time AS
+         (
+             SELECT CASE
+                        WHEN rnk <= 100 THEN cast(userid as char(6))
+                        ELSE 'Other Users'
+                        END                                                             AS usename,
+                    queue,
+                    aborted,
+                    'Execution Time'                                                    AS measure_type,
+                    COUNT(*)                                                            AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p99_s,
+                    MAX(exec_time_s)                                                    AS max_s,
+                    AVG(exec_time_s)                                                    AS avg_s,
+                    stddev(exec_time_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1,
+                      2,
+                      3,
+                      4
+         ),
+     queue_time AS
+         (
+             SELECT CASE
+                        WHEN rnk <= 100 THEN cast(userid as char(6))
+                        ELSE 'Other Users'
+                        END                                                         AS usename,
+                    queue,
+                    aborted,
+                    'Queue Time'                                                    AS measure_type,
+                    COUNT(*)                                                        AS query_count,
+                    ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY queue_s), 2) AS p25_s,
+                    ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY queue_s), 2) AS p50_s,
+                    ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY queue_s), 2) AS p75_s,
+                    ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY queue_s), 2) AS p90_s,
+                    ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY queue_s), 2) AS p95_s,
+                    ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY queue_s), 2) AS p99_s,
+                    MAX(queue_s)                                                    AS max_s,
+                    AVG(queue_s)                                                    AS avg_s,
+                    stddev(queue_s)                                                 AS std_s
+             FROM queries
+             GROUP BY 1,
+                      2,
+                      3,
+                      4
+         )
 SELECT measure_type,
        usename,
        queue,

--- a/core/sql/query_metrics.sql
+++ b/core/sql/query_metrics.sql
@@ -1,19 +1,17 @@
-select
-q.user_id as "userid"
-,TRIM(u.usename) AS usename
-,case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
-,date_trunc('hour', q.start_time) as "period"
-,q.transaction_id as "xid"
-,q.query_id as "query"
-,q.query_text::char(50) as "querytxt"
-,q.queue_time / 1000000.00 as "queue_s"
-,q.execution_time / 1000000.00 as "exec_time_s" -- This includes compile time. Differs in behavior from provisioned metric
-,case when q.status = 'failed' then 1 else 0 end "aborted"
-,q.elapsed_time / 1000000.00 as "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
+/*QueryMetrics*/
+select q.user_id                                                                       as "userid"
+     , case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
+     , date_trunc('hour', q.start_time)                                                as "period"
+     , q.transaction_id                                                                as "xid"
+     , q.query_id                                                                      as "query"
+     , q.query_text::char(50)                                                          as "querytxt"
+     , q.queue_time / 1000000.00                                                       as "queue_s"
+     , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
+     , case when q.status = 'failed' then 1 else 0 end                                    "aborted"
+     , q.elapsed_time / 1000000.00                                                     as "total_elapsed_s" -- This includes compile time. Differs in behavior from provisioned metric
 FROM sys_query_history q
-LEFT JOIN pg_user u ON u.usesysid = q.user_id
 WHERE q.user_id > 1
-  AND   q.start_time >={{START_TIME}}
-  AND   q.start_time <={{END_TIME}}
-  AND   q.query_text LIKE '%replay_start%'
-  AND   q.status != 'failed';
+  AND q.start_time >={{START_TIME}}
+  AND q.start_time <={{END_TIME}}
+  AND q.query_text LIKE '%replay_start%'
+  AND q.status != 'failed';

--- a/core/sql/statement_types.sql
+++ b/core/sql/statement_types.sql
@@ -1,46 +1,45 @@
-SELECT
-    CASE
-      WHEN REGEXP_INSTR ("query_text",'(padb_|pg_internal)')
-      THEN 'SYSTEM'
-      WHEN query_type = 'DELETE'
-      THEN 'DELETE'
-      WHEN query_type = 'COPY'
-      THEN 'COPY'
-      WHEN query_type = 'UPDATE'
-      THEN 'UPDATE'
-      WHEN query_type = 'INSERT'
-      THEN 'INSERT'
-      WHEN query_type = 'SELECT'
-      THEN 'SELECT'
-      WHEN query_type = 'UNLOAD'
-      THEN 'UNLOAD'
-      WHEN query_type = 'DDL'
-      THEN 'DDL'
-      WHEN query_type = 'UTILITY'
-      THEN CASE
-             WHEN REGEXP_INSTR ("query_text",'[vV][aA][cC][uU][uU][mM][ :]')
-             THEN 'VACUUM'
-             WHEN REGEXP_INSTR ("query_text",'[rR][oO][lL][lL][bB][aA][cC][kK] ')
-             THEN 'ROLLBACK'
-             WHEN REGEXP_INSTR ("query_text",'[fF][eE][tT][cC][hH] ')
-             THEN 'FETCH'
-             WHEN REGEXP_INSTR ("query_text",'[cC][uU][rR][sS][oO][rR] ')
-             THEN 'CURSOR'
-             ELSE 'UTILITY'
-           END
-      ELSE 'OTHER'
-    END statement_type
-    , COUNT(CASE
-              WHEN status = 'failed'
-              THEN 1
-            END) AS aborted
-    , COUNT(*) AS total_count
-FROM
-    sys_query_history
-WHERE    user_id > 1
-         AND query_text LIKE '%replay_start%'
-         AND start_time >= {{START_TIME}}
-         AND start_time <= {{END_TIME}}
+/*StatementTypes*/
+SELECT CASE
+           WHEN REGEXP_INSTR("query_text", '(padb_|pg_internal)')
+               THEN 'SYSTEM'
+           WHEN query_type = 'DELETE'
+               THEN 'DELETE'
+           WHEN query_type = 'COPY'
+               THEN 'COPY'
+           WHEN query_type = 'UPDATE'
+               THEN 'UPDATE'
+           WHEN query_type = 'INSERT'
+               THEN 'INSERT'
+           WHEN query_type = 'SELECT'
+               THEN 'SELECT'
+           WHEN query_type = 'UNLOAD'
+               THEN 'UNLOAD'
+           WHEN query_type = 'DDL'
+               THEN 'DDL'
+           WHEN query_type = 'UTILITY'
+               THEN CASE
+                        WHEN REGEXP_INSTR("query_text", '[vV][aA][cC][uU][uU][mM][ :]')
+                            THEN 'VACUUM'
+                        WHEN REGEXP_INSTR("query_text", '[rR][oO][lL][lL][bB][aA][cC][kK] ')
+                            THEN 'ROLLBACK'
+                        WHEN REGEXP_INSTR("query_text", '[fF][eE][tT][cC][hH] ')
+                            THEN 'FETCH'
+                        WHEN REGEXP_INSTR("query_text", '[cC][uU][rR][sS][oO][rR] ')
+                            THEN 'CURSOR'
+                        ELSE 'UTILITY'
+               END
+           ELSE 'OTHER'
+    END            statement_type
+     , COUNT(CASE
+                 WHEN status = 'failed'
+                     THEN 1
+    END)        AS aborted
+     , COUNT(*) AS total_count
+FROM sys_query_history
+WHERE user_id > 1
+  AND query_text LIKE '%replay_start%'
+  AND start_time >= {{START_TIME}}
+  AND start_time <= {{END_TIME}}
 GROUP BY
     1
 ORDER BY

--- a/core/sql/sys_external_query_data.sql
+++ b/core/sql/sys_external_query_data.sql
@@ -1,3 +1,4 @@
+/*SysExternalQueryData*/
 SELECT user_id,
        query_id,
        child_query_sequence,
@@ -14,8 +15,8 @@ SELECT user_id,
        returned_bytes,
        file_format,
        file_location,
-       external_query_text from SYS_EXTERNAL_QUERY_DETAIL
-    WHERE user_id > 1
-      AND   start_time >= {{START_TIME}}
-      AND   start_time <= {{END_TIME}};
-    ;
+       external_query_text
+from SYS_EXTERNAL_QUERY_DETAIL
+WHERE user_id > 1
+  AND start_time >= {{START_TIME}}
+  AND start_time <= {{END_TIME}};

--- a/core/sql/sys_load_history.sql
+++ b/core/sql/sys_load_history.sql
@@ -1,19 +1,21 @@
+/*SysLoadHistory*/
 SELECT user_id,
-query_id,
-status,
-session_id,
-transaction_id,
-database_name,
-table_name,
-start_time,
-end_time,
-duration,
-data_source,
-loaded_rows,
-loaded_bytes,
-source_file_count,
-source_file_bytes,
-error_count from SYS_LOAD_HISTORY
+       query_id,
+       status,
+       session_id,
+       transaction_id,
+       database_name,
+       table_name,
+       start_time,
+       end_time,
+       duration,
+       data_source,
+       loaded_rows,
+       loaded_bytes,
+       source_file_count,
+       source_file_bytes,
+       error_count
+from SYS_LOAD_HISTORY
 WHERE user_id > 1
-  AND   start_time >= {{START_TIME}}
-  AND   start_time <= {{END_TIME}};
+  AND start_time >= {{START_TIME}}
+  AND start_time <= {{END_TIME}};

--- a/core/sql/sys_query_history.sql
+++ b/core/sql/sys_query_history.sql
@@ -1,5 +1,5 @@
+/*SysQueryHistory*/
 SELECT h.user_id,
-       u.usename as user_name,
        query_id,
        transaction_id,
        session_id,
@@ -17,9 +17,8 @@ SELECT h.user_id,
        error_message,
        returned_rows,
        returned_bytes,
-       redshift_version from sys_query_history h
-       LEFT JOIN pg_user u on h.user_id=u.usesysid
+       redshift_version
+from sys_query_history h
 WHERE user_id > 1
-  AND   start_time >= {{START_TIME}}
-  AND   start_time <= {{END_TIME}};
-;
+  AND start_time >= {{START_TIME}}
+  AND start_time <= {{END_TIME}};


### PR DESCRIPTION
*Issue #, if available:*
The issue is the query we currently have for getting replay stats uses pg tables and sys_views. The problem is having both these tables generates an execution plan that runs on Leader Node and the Compute Nodes. This causes a problem in Redshift and throws an error in some Redshift clusters

*Description of changes:*
To fix this issue, I removed the pg tables that are Leader Node only tables. This way we have an execution plan that runs only on the Compute nodes.

To verify that the new query generates a execution plan that does not involve Leader Node and Compute Node, I ran both the old query and the new query and verified that the new query does not have a LN step compared to the old query that will have an LN step in the execution plan.

Test Cluster - ra3-redshift-cluster-testing
Old query with pg table -(rewritten_query_id 27420851)
New query without pg table - (rewritten_query_id 27419945)

