### PR TITLE
making DEBUG as the default

### DIFF
--- a/config/replay.yaml
+++ b/config/replay.yaml
@@ -71,7 +71,7 @@ filters:
 ##
 
 # Set the amount of logging
-log_level: "INFO"
+log_level: "DEBUG"
 
 # number of proceses to use to parallelize the work. If omitted or null, uses
 # one process per cpu - 1 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Currently with INFO as the loglevel, it is hard to debug what customer is facing. Also since customers dont prefer running the entire replay just for changing the debug level, I am converting this to DEBUG so it will help us start working on the issue instead of waiting for the customer to rerun the replay.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
