### PR TITLE
fixing bug to allow replay to connect to multiple databases

### DIFF
--- a/core/replay/prep.py
+++ b/core/replay/prep.py
@@ -139,7 +139,8 @@ class ReplayPrep:
             cluster_host = cluster_endpoint.split(":")[0]
 
         cluster_port = cluster_endpoint_split[5].split("/")[0][4:]
-        database = cluster_endpoint_split[5].split("/")[1]
+        if database == None:
+            database = cluster_endpoint_split[5].split("/")[1]
 
         additional_args = {}
         if os.environ.get("ENDPOINT_URL"):

--- a/core/tests/test_prep.py
+++ b/core/tests/test_prep.py
@@ -266,6 +266,30 @@ class TestGetConnectionCredentials(unittest.TestCase):
                 "database": "dev",
             },
         )
+    
+    @patch("core.replay.prep.redshift_get_cluster_credentials")
+    def test_get_connection_credentials_for_database_not_being_none(self, mock_get_cluster_creds):
+        mock_get_cluster_creds.return_value = {"DbUser": "testAdmin", "DbPassword": "testPassword"}
+        prep = ReplayPrep(
+            {
+                "target_cluster_endpoint": "test.111222333222.us-east-1.redshift.amazonaws.com:5439/dev",
+                "odbc_driver": "test",
+                "nlb_nat_dns": None,
+                "target_cluster_region": "us-east-1",
+            }
+        )
+
+        result = prep.get_connection_credentials("testUsername","tcpds_100g")
+        self.assertEqual(
+            result["psql"],
+            {
+                "username": "testAdmin",
+                "password": "testPassword",
+                "host": "test.111222333222.us-east-1.redshift.amazonaws.com",
+                "port": "5439",
+                "database": "tcpds_100g",
+            },
+        )
 
 
 class TestCorrelateTransactionsWithConnections(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ botocore==1.27.24
 Flask==2.2.5
 matplotlib==3.5.2
 moto==3.1.16
-numpy
+numpy==1.26.4
 pandas
 python-dateutil==2.8.1
 PyYAML==6.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will let replay run multiple databases. Also the if statement is required because when we call this function from unload_sys_table.py we dont pass the database then we just take the database from the cluster endpoint.
