### PR TITLE
Call pip and flask via python3 to ensure venv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+testDriveEnv/
 
 # Spyder project settings
 .spyderproject

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ external_object_replicator:
 
 
 setup: requirements.txt
-	pip3 install -r requirements.txt
+	$(PYTHON) -m pip install -r requirements.txt
 
 test:
 	export PYTHONPATH=$(PYTHONPATH):$(CORE_FOLDER):$(CORE_FOLDER) && export PYTHONPATH=$(PYTHONPATH):$(CORE_FOLDER):$(COMMON_FOLDER) && export PYTHONPATH=$(PYTHONPATH):$(CORE_FOLDER):$(EXTERNAL_OBJECT_REPLICATOR_DIR)/ && export PYTHONPATH=$(PYTHONPATH):$(CORE_FOLDER):$(REPLAY_ANALYSIS_DIR)/ && pytest ${EXTERNAL_OBJECT_REPLICATOR_DIR} ${CORE_FOLDER} ${COMMON_FOLDER} ${REPLAY_ANALYSIS_DIR}

--- a/tools/ReplayAnalysis/gui/package.json
+++ b/tools/ReplayAnalysis/gui/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start-backend": "cd ../api && flask run",
+    "start-backend": "cd ../api && python3 -m flask run",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/tools/ReplayAnalysis/replay_analysis.py
+++ b/tools/ReplayAnalysis/replay_analysis.py
@@ -8,7 +8,7 @@ def launch_analysis_v2():
 
     # add explicit instructions for user
 
-    os.system("pip install -r requirements.txt")
+    os.system("python3 -m pip install -r requirements.txt")
     os.chdir(f"{os.getcwd()}/tools/ReplayAnalysis/gui")
 
     # explicit version checking


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Calling pip3 directly was bypassing the venv and causing dependencies to be installed globally. Running everything via the `python3` fixes this and utilises the virtual environment as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
