### PR TITLE
Improved to support China region endpoint 

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -37,28 +37,54 @@ def validate_config_file_for_extract(config):
     :return:
     """
     if config["source_cluster_endpoint"]:
-        if "redshift-serverless" in config["source_cluster_endpoint"]:
-            if (
+        ## China region endpoint support. G.Bai - Mar 2025
+        if ".com.cn" in config["source_cluster_endpoint"] and len(config["source_cluster_endpoint"].split(".")) == 7:
+            if "redshift-serverless" in config["source_cluster_endpoint"]:
+                if (
+                    not len(config["source_cluster_endpoint"].split(".")) == 7
+                    or not len(config["source_cluster_endpoint"].split(":")) == 2
+                    or not len(config["source_cluster_endpoint"].split("/")) == 2
+                ):
+                    logger.error(
+                        'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in '
+                        "the format of <identifier>.<region>.redshift-serverless.amazonaws.com.cn:<port>/<database-name>. "
+                    )
+                    exit(-1)
+            elif (
+                not len(config["source_cluster_endpoint"].split(".")) == 7
+                or not len(config["source_cluster_endpoint"].split(":")) == 2
+                or not len(config["source_cluster_endpoint"].split("/")) == 2
+                or ".redshift.amazonaws.com.cn" not in config["source_cluster_endpoint"]
+            ):
+                logger.error(
+                    'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in the '
+                    "format of <cluster-name>.<identifier>.<region>.redshift.amazonaws.com.cn:<port>/<database-name>. "
+                )
+                exit(-1)
+        else:
+            if "redshift-serverless" in config["source_cluster_endpoint"]:
+                if (
+                    not len(config["source_cluster_endpoint"].split(".")) == 6
+                    or not len(config["source_cluster_endpoint"].split(":")) == 2
+                    or not len(config["source_cluster_endpoint"].split("/")) == 2
+                ):
+                    logger.error(
+                        'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in '
+                        "the format of <identifier>.<region>.redshift-serverless.amazonaws.com:<port>/<database-name>. "
+                    )
+                    exit(-1)
+            elif (
                 not len(config["source_cluster_endpoint"].split(".")) == 6
                 or not len(config["source_cluster_endpoint"].split(":")) == 2
                 or not len(config["source_cluster_endpoint"].split("/")) == 2
+                or ".redshift.amazonaws.com:" not in config["source_cluster_endpoint"]
             ):
                 logger.error(
-                    'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in '
-                    "the format of <identifier>.<region>.redshift-serverless.amazonaws.com:<port>/<database-name>. "
+                    'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in the '
+                    "format of <cluster-name>.<identifier>.<region>.redshift.amazonaws.com:<port>/<database-name>. "
                 )
                 exit(-1)
-        elif (
-            not len(config["source_cluster_endpoint"].split(".")) == 6
-            or not len(config["source_cluster_endpoint"].split(":")) == 2
-            or not len(config["source_cluster_endpoint"].split("/")) == 2
-            or ".redshift.amazonaws.com:" not in config["source_cluster_endpoint"]
-        ):
-            logger.error(
-                'Config file value for "source_cluster_endpoint" is not a valid endpoint. Endpoints must be in the '
-                "format of <cluster-name>.<identifier>.<region>.redshift.amazonaws.com:<port>/<database-name>. "
-            )
-            exit(-1)
+
         if not config["master_username"]:
             logger.error(
                 'Config file missing value for "master_username". Please provide a value or remove the '

--- a/common/config.py
+++ b/common/config.py
@@ -174,9 +174,14 @@ def validate_config_file_for_extract(config):
 
 
 def validate_config_for_replay(config):
-    cluster_endpoint_pattern = (
-        r"(.+)\.(.+)\.(.+).redshift(-serverless)?\.amazonaws\.com:[0-9]{4,5}\/(.)+"
-    )
+    if ".com.cn" in config["target_cluster_endpoint"] and len(config["target_cluster_endpoint"].split(".")) == 7:
+        cluster_endpoint_pattern = (
+            r"(.+)\.(.+)\.(.+).redshift(-serverless)?\.amazonaws\.com\.cn:[0-9]{4,5}\/(.)+"
+        )
+    else:
+        cluster_endpoint_pattern = (
+            r"(.+)\.(.+)\.(.+).redshift(-serverless)?\.amazonaws\.com:[0-9]{4,5}\/(.)+"
+        )
     if not bool(re.fullmatch(cluster_endpoint_pattern, config["target_cluster_endpoint"])):
         logger.error(
             'Config file value for "target_cluster_endpoint" is not a valid endpoint. Endpoints must be in the format '

--- a/common/util.py
+++ b/common/util.py
@@ -177,6 +177,8 @@ def get_connection_key(database_name, username, pid):
 
 
 def is_serverless(config):
+    if ".com.cn" in config["target_cluster_endpoint"] and len(config["target_cluster_endpoint"].split(".")) == 7:
+        serverless_cluster_endpoint_pattern = (r"(.+)\.(.+)\.(.+).redshift-serverless(-dev)?\.amazonaws\.com\.cn:[0-9]{4,5}\/(.)+")
     return bool(
         re.fullmatch(serverless_cluster_endpoint_pattern, config["target_cluster_endpoint"])
     )

--- a/core/extract/extract.py
+++ b/core/extract/extract.py
@@ -15,11 +15,6 @@ import core.extract.extractor as extractor
 
 logger = logging.getLogger("WorkloadReplicatorLogger")
 
-serverless_cluster_endpoint_pattern = (
-    r"(.+)\.(.+)\.(.+).redshift-serverless(-dev)?\.amazonaws\.com:[0-9]{4,5}\/(.)+"
-)
-
-
 def is_serverless(config):
     return bool(
             re.fullmatch(serverless_cluster_endpoint_pattern, config["source_cluster_endpoint"])
@@ -76,6 +71,16 @@ def main():
     # setting application name for tracking
     if config.get("source_cluster_endpoint"):
         application = "WorkloadReplicator-Extract"
+        ##China region endpoint - G.Bai - Mar 2025
+        global serverless_cluster_endpoint_pattern
+        if ".com.cn" in config.get("source_cluster_endpoint") and len(config.get("source_cluster_endpoint").split(".")) == 7:
+            serverless_cluster_endpoint_pattern = (
+            r"(.+)\.(.+)\.(.+).redshift-serverless(-dev)?\.amazonaws\.com\.cn:[0-9]{4,5}\/(.)+"
+            )
+        else:
+            serverless_cluster_endpoint_pattern = (
+            r"(.+)\.(.+)\.(.+).redshift-serverless(-dev)?\.amazonaws\.com:[0-9]{4,5}\/(.)+"
+            )
 
         if is_serverless(config):
             host = f'redshift-serverless-{config.get("source_cluster_endpoint").split(".")[0]}' 

--- a/core/extract/extractor.py
+++ b/core/extract/extractor.py
@@ -391,12 +391,21 @@ class Extractor:
         cluster_region = cluster_endpoint.split(".")[2]
         cluster_id = cluster_endpoint_split[0]
         cluster_host = cluster_endpoint.split(":")[0]
-        if "redshift-serverless" in cluster_endpoint:
-            cluster_port = cluster_endpoint_split[5].split("/")[0][4:]
-            cluster_database = cluster_endpoint_split[5].split("/")[1]
+        ## China region endpoint support - G.Bai - Mar 2025
+        if ".com.cn" in cluster_endpoint and len(cluster_endpoint.split(".")) == 7:
+            if "redshift-serverless" in cluster_endpoint:
+                cluster_port = cluster_endpoint_split[6].split(":")[1].split("/")[0]
+                cluster_database = cluster_endpoint_split[6].split("/")[1]
+            else:
+                cluster_port = cluster_endpoint_split[6].split(":")[1].split("/")[0]
+                cluster_database = cluster_endpoint_split[6].split("/")[1]
         else:
-            cluster_port = cluster_endpoint_split[5].split("/")[0][4:]
-            cluster_database = cluster_endpoint_split[5].split("/")[1]
+            if "redshift-serverless" in cluster_endpoint:
+                cluster_port = cluster_endpoint_split[5].split("/")[0][4:]
+                cluster_database = cluster_endpoint_split[5].split("/")[1]
+            else:
+                cluster_port = cluster_endpoint_split[5].split("/")[0][4:]
+                cluster_database = cluster_endpoint_split[5].split("/")[1]
         try:
             if "redshift-serverless" in cluster_endpoint:
                 response = client.get_credentials(

--- a/core/replay/connection_thread.py
+++ b/core/replay/connection_thread.py
@@ -104,6 +104,10 @@ class ConnectionThread(threading.Thread):
         else:
             interface = "psql"
         r = ReplayPrep(self.config)
+        ##Fix IAM user bug. G.Bai - mar 2025
+        if username[:4] == "IAM:" or username[:5] == "IAMR:" or username.count(":") == 2:
+            self.logger.debug("Replace user - " + username + " to " + self.config["master_username"])
+            username = self.config["master_username"]
         credentials = r.get_connection_credentials(username, database=self.connection_log.database_name)
 
         try:


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Refer to the below example, the first is global endpoint, the other one is for ZHY in China region.
There is extra element ‘.cn’ which is the seventh as the port/DB for global clusters.
As a result, this utility is not working for the clusters in China region.
	clusterabc.cbiyohkdprra.us-east-2.redshift.amazonaws.com:5439/dev
	clusterabc.cm4u43pp7hs1.cn-northwest-1.redshift.amazonaws.com.cn:5439/dev

This phase of pull request improved the codes to adapt both global endpoint and China region endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
