### PR TITLE
Fix replay-analysis UNLOAD failure on non-ASCII query_text (error 8001)

### DIFF
--- a/core/replay/report_gen.py
+++ b/core/replay/report_gen.py
@@ -373,7 +373,11 @@ def unload(unload_location, iam_role, cluster, user, replay):
                 if "CREATE TEMP TABLE" in query:
                     query_split = query.split('\n\n')
                     try:
-                        cursor.execute(query_split[0])
+                        # The setup block may contain more than one ;-separated
+                        # statement (e.g. staging temp tables). Execute each in turn.
+                        for setup_statement in query_split[0].split(";"):
+                            if setup_statement.strip():
+                                cursor.execute(setup_statement)
 
                         unload_query = (
                             f"unload ($${query_split[1]}$$) to '{parsed_location}analysis/{replay}/raw_data/"

--- a/core/sql/aborted_queries.sql
+++ b/core/sql/aborted_queries.sql
@@ -5,7 +5,7 @@ CREATE TEMP TABLE aborted_queries AS (
          , date_trunc('hour', q.start_time)                                                as "period"
          , q.transaction_id                                                                as "xid"
          , q.query_id                                                                      as "query"
-         , q.query_text::char(50)                                                          as "querytxt"
+         , q.query_text::varchar(50)                                                       as "querytxt"
          , q.queue_time / 1000000.00                                                       as "queue_s"
          , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
          , case when q.status = 'failed' then 1 else 0 end                                    "aborted"

--- a/core/sql/cluster_level_metrics.sql
+++ b/core/sql/cluster_level_metrics.sql
@@ -5,7 +5,6 @@ WITH queries AS
                   , date_trunc('hour', q.start_time) as             "period"
                   , q.transaction_id                 as             "xid"
                   , q.query_id                       as             "query"
-                  , q.query_text::char(50)           as             "querytxt"
                   , q.queue_time / 1000000.00        as             "queue_s"
                   , q.execution_time / 1000000.00    as             "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
                   , case when q.status = 'failed' then 1 else 0 end "aborted"

--- a/core/sql/latency_distribution.sql
+++ b/core/sql/latency_distribution.sql
@@ -1,63 +1,12 @@
+CREATE TEMP TABLE replay_queries AS
+SELECT q.query_id
+     , q.elapsed_time / 1000000.00 AS total_elapsed_s
+FROM sys_query_history q
+WHERE q.user_id > 1
+  AND q.start_time >= {{START_TIME}}
+  AND q.start_time <= {{END_TIME}}
+  AND q.query_text LIKE '%replay_start%'
+  AND status != 'failed';
+
 /*LatencyDistribution*/
-WITH queries AS
-         (
-             SELECT q.query_id
-                  , q.elapsed_time / 1000000.00 as total_elapsed_s
-             FROM sys_query_history q
-             WHERE q.user_id > 1
-               AND q.start_time >= {{START_TIME}}
-               AND q.start_time <= {{END_TIME}}
-               AND q.query_text LIKE '%replay_start%'
-               AND status != 'failed'
-         )
-        ,
-     pct AS
-         (
-             SELECT ROUND(PERCENTILE_CONT(0.98) WITHIN GROUP (ORDER BY q1.total_elapsed_s), 2) AS  p98_s,
-                    COUNT(*)                                                                   AS  query_count,
-                    MAX(q1.total_elapsed_s)                                                        max_s,
-                    MIN(q1.total_elapsed_s)                                                        min_s,
-                    MIN(CASE WHEN q1.total_elapsed_s = 0.00 THEN NULL ELSE q1.total_elapsed_s END) min_2s
-             FROM queries q1
-         ),
-     bucket_count AS
-         (
-             SELECT CASE
-                        WHEN query_count > 100 THEN 40
-                        ELSE 5
-                        END AS b_count
-             FROM pct
-         ),
-     buckets AS
-         (
-             SELECT (min_2s + ((n) * (p98_s / b_count)))     AS sec_end,
-                    n,
-                    (min_2s + ((n - 1) * (p98_s / b_count))) AS sec_start
-             FROM (SELECT ROW_NUMBER() OVER () n FROM pg_class LIMIT 39),
-                  bucket_count,
-                  pct
-             WHERE sec_end <= p98_s
-             UNION ALL
-             SELECT min_2s AS sec_end,
-                    0      AS n,
-                    0.00   AS sec_start
-             FROM pct
-             UNION ALL
-             SELECT (max_s + 0.01) AS sec_end,
-                    b_count        AS n,
-                    p98_s          AS sec_start
-             FROM pct,
-                  bucket_count
-         )
-SELECT sec_end,
-       n,
-       sec_start,
-       COUNT(query_id)
-FROM buckets
-         LEFT JOIN queries
-                   ON total_elapsed_s >= sec_start
-                       AND total_elapsed_s < sec_end
-GROUP BY 1,
-         2,
-         3
-ORDER BY 2;
+WITH queries AS (SELECT query_id, total_elapsed_s FROM replay_queries), pct AS (SELECT ROUND(PERCENTILE_CONT(0.98) WITHIN GROUP (ORDER BY q1.total_elapsed_s), 2) AS p98_s, COUNT(*) AS query_count, MAX(q1.total_elapsed_s) AS max_s, MIN(q1.total_elapsed_s) AS min_s, MIN(CASE WHEN q1.total_elapsed_s = 0.00 THEN NULL ELSE q1.total_elapsed_s END) AS min_2s FROM queries q1), bucket_count AS (SELECT CASE WHEN query_count > 100 THEN 40 ELSE 5 END AS b_count FROM pct), buckets AS (SELECT (min_2s + ((n) * (p98_s / b_count))) AS sec_end, n, (min_2s + ((n - 1) * (p98_s / b_count))) AS sec_start FROM (SELECT ROW_NUMBER() OVER () n FROM pg_class LIMIT 39), bucket_count, pct WHERE sec_end <= p98_s UNION ALL SELECT min_2s AS sec_end, 0 AS n, 0.00 AS sec_start FROM pct UNION ALL SELECT (max_s + 0.01) AS sec_end, b_count AS n, p98_s AS sec_start FROM pct, bucket_count) SELECT sec_end, n, sec_start, COUNT(query_id) FROM buckets LEFT JOIN queries ON total_elapsed_s >= sec_start AND total_elapsed_s < sec_end GROUP BY 1, 2, 3 ORDER BY 2

--- a/core/sql/query_distribution.sql
+++ b/core/sql/query_distribution.sql
@@ -1,177 +1,19 @@
-/*QueryDistribution*/
-CREATE TEMP TABLE query_distribution AS (
-    WITH queries AS
-             (
-                 select q.user_id                                                                       as "userid"
-                      , case when q.result_cache_hit = 't' then 'Result Cache' else 'Default queue' end as "queue"
-                      , date_trunc('hour', q.start_time)                                                as "period"
-                      , q.transaction_id                                                                as "xid"
-                      , q.query_id                                                                      as "query"
-                      , q.query_text::char(50)                                                          as "querytxt"
-                      , q.queue_time / 1000000.00                                                       as "queue_s"
-                      , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
-                      , case when q.status = 'failed' then 1 else 0 end                                    "aborted"
-                      , q.elapsed_time / 1000000.00                                                     as "total_elapsed_s" --again includes compile time
-                      , user_query_count
-                      , DENSE_RANK() OVER (ORDER BY user_query_count)                                   AS rnk
-                 FROM sys_query_history q
-                          inner join (select user_id, count(*) user_query_count
-                                      from sys_query_history
-                                      where user_id > 1
-                                        AND start_time >={{START_TIME}}
-                                        AND start_time <={{END_TIME}}
-                                        AND query_text LIKE '%replay_start%'
-                                        AND status != 'failed'
-                                      group by user_id) uc on uc.user_id = q.user_id
-                 WHERE q.user_id > 1
-                   AND q.start_time >={{START_TIME}}
-                   AND q.start_time <={{END_TIME}}
-                   AND q.query_text LIKE '%replay_start%'
-                   AND q.status != 'failed'
-             ),
-         elapsed_time AS
-             (
-                 SELECT userid,
-                        rnk,
-                        queue,
-                        aborted,
-                        'Query Latency'                                                         AS measure_type,
-                        COUNT(*)                                                                AS query_count,
-                        ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p25_s,
-                        ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p50_s,
-                        ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p75_s,
-                        ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p90_s,
-                        ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p95_s,
-                        ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY total_elapsed_s), 2) AS p99_s,
-                        MAX(total_elapsed_s)                                                    AS max_s,
-                        AVG(total_elapsed_s)                                                    AS avg_s,
-                        stddev(total_elapsed_s)                                                 AS std_s
-                 FROM queries
-                 GROUP BY 1,
-                          2,
-                          3,
-                          4,
-                          5
-             ),
-         exec_time AS
-             (
-                 SELECT userid,
-                        rnk,
-                        queue,
-                        aborted,
-                        'Execution Time'                                                    AS measure_type,
-                        COUNT(*)                                                            AS query_count,
-                        ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p25_s,
-                        ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p50_s,
-                        ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p75_s,
-                        ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p90_s,
-                        ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p95_s,
-                        ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY exec_time_s), 2) AS p99_s,
-                        MAX(exec_time_s)                                                    AS max_s,
-                        AVG(exec_time_s)                                                    AS avg_s,
-                        stddev(exec_time_s)                                                 AS std_s
-                 FROM queries
-                 GROUP BY 1,
-                          2,
-                          3,
-                          4,
-                          5
-             ),
-         queue_time AS
-             (
-                 SELECT userid,
-                        rnk,
-                        queue,
-                        aborted,
-                        'Queue Time'                                                    AS measure_type,
-                        COUNT(*)                                                        AS query_count,
-                        ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY queue_s), 2) AS p25_s,
-                        ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY queue_s), 2) AS p50_s,
-                        ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY queue_s), 2) AS p75_s,
-                        ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY queue_s), 2) AS p90_s,
-                        ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY queue_s), 2) AS p95_s,
-                        ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY queue_s), 2) AS p99_s,
-                        MAX(queue_s)                                                    AS max_s,
-                        AVG(queue_s)                                                    AS avg_s,
-                        stddev(queue_s)                                                 AS std_s
-                 FROM queries
-                 GROUP BY 1,
-                          2,
-                          3,
-                          4,
-                          5
-             )
-    SELECT measure_type,
-           userid,
-           rnk,
-           queue,
-           aborted,
-           query_count,
-           p25_s,
-           p50_s,
-           p75_s,
-           p90_s,
-           p95_s,
-           p99_s,
-           max_s,
-           avg_s,
-           std_s
-    FROM exec_time
-    UNION ALL
-    SELECT measure_type,
-           userid,
-           rnk,
-           queue,
-           aborted,
-           query_count,
-           p25_s,
-           p50_s,
-           p75_s,
-           p90_s,
-           p95_s,
-           p99_s,
-           max_s,
-           avg_s,
-           std_s
-    FROM queue_time
-    UNION ALL
-    SELECT measure_type,
-           userid,
-           rnk,
-           queue,
-           aborted,
-           query_count,
-           p25_s,
-           p50_s,
-           p75_s,
-           p90_s,
-           p95_s,
-           p99_s,
-           max_s,
-           avg_s,
-           std_s
-    FROM elapsed_time
-);
+CREATE TEMP TABLE qd_base AS
+SELECT q.user_id AS userid
+     , CASE WHEN q.result_cache_hit = 't' THEN 'Result Cache' ELSE 'Default queue' END AS queue
+     , date_trunc('hour', q.start_time) AS period
+     , q.transaction_id AS xid
+     , q.query_id AS query
+     , q.queue_time / 1000000.00 AS queue_s
+     , q.execution_time / 1000000.00 AS exec_time_s
+     , CASE WHEN q.status = 'failed' THEN 1 ELSE 0 END AS aborted
+     , q.elapsed_time / 1000000.00 AS total_elapsed_s
+FROM sys_query_history q
+WHERE q.user_id > 1
+  AND q.start_time >= {{START_TIME}}
+  AND q.start_time <= {{END_TIME}}
+  AND q.query_text LIKE '%replay_start%'
+  AND q.status != 'failed';
+CREATE TEMP TABLE query_distribution AS (WITH queries AS (SELECT qb.userid, qb.queue, qb.period, qb.xid, qb.query, qb.queue_s, qb.exec_time_s, qb.aborted, qb.total_elapsed_s, uc.user_query_count, DENSE_RANK() OVER (ORDER BY uc.user_query_count) AS rnk FROM qd_base qb INNER JOIN (SELECT userid, count(*) AS user_query_count FROM qd_base GROUP BY userid) uc ON uc.userid = qb.userid), elapsed_time AS (SELECT userid, rnk, queue, aborted, 'Query Latency' AS measure_type, COUNT(*) AS query_count, ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p25_s, ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p50_s, ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p75_s, ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p90_s, ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p95_s, ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY total_elapsed_s),2) AS p99_s, MAX(total_elapsed_s) AS max_s, AVG(total_elapsed_s) AS avg_s, stddev(total_elapsed_s) AS std_s FROM queries GROUP BY 1,2,3,4,5), exec_time AS (SELECT userid, rnk, queue, aborted, 'Execution Time' AS measure_type, COUNT(*) AS query_count, ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY exec_time_s),2) AS p25_s, ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY exec_time_s),2) AS p50_s, ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY exec_time_s),2) AS p75_s, ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY exec_time_s),2) AS p90_s, ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY exec_time_s),2) AS p95_s, ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY exec_time_s),2) AS p99_s, MAX(exec_time_s) AS max_s, AVG(exec_time_s) AS avg_s, stddev(exec_time_s) AS std_s FROM queries GROUP BY 1,2,3,4,5), queue_time AS (SELECT userid, rnk, queue, aborted, 'Queue Time' AS measure_type, COUNT(*) AS query_count, ROUND(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY queue_s),2) AS p25_s, ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY queue_s),2) AS p50_s, ROUND(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY queue_s),2) AS p75_s, ROUND(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY queue_s),2) AS p90_s, ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY queue_s),2) AS p95_s, ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY queue_s),2) AS p99_s, MAX(queue_s) AS max_s, AVG(queue_s) AS avg_s, stddev(queue_s) AS std_s FROM queries GROUP BY 1,2,3,4,5) SELECT measure_type, userid, rnk, queue, aborted, query_count, p25_s, p50_s, p75_s, p90_s, p95_s, p99_s, max_s, avg_s, std_s FROM exec_time UNION ALL SELECT measure_type, userid, rnk, queue, aborted, query_count, p25_s, p50_s, p75_s, p90_s, p95_s, p99_s, max_s, avg_s, std_s FROM queue_time UNION ALL SELECT measure_type, userid, rnk, queue, aborted, query_count, p25_s, p50_s, p75_s, p90_s, p95_s, p99_s, max_s, avg_s, std_s FROM elapsed_time);
 
-SELECT a.measure_type,
-           CASE 
-            WHEN rnk <= 100 THEN u.usename
-            ELSE 'Other Users' END as usename,
-           a.queue,
-           a.aborted,
-           a.query_count,
-           a.p25_s,
-           a.p50_s,
-           a.p75_s,
-           a.p90_s,
-           a.p95_s,
-           a.p99_s,
-           a.max_s,
-           a.avg_s,
-           a.std_s
-FROM query_distribution a 
-    LEFT JOIN pg_user u on a.userid = u.usesysid
-    ORDER BY 1,
-             2,
-             3,
-             4;
+SELECT a.measure_type, CASE WHEN rnk <= 100 THEN u.usename ELSE 'Other Users' END AS usename, a.queue, a.aborted, a.query_count, a.p25_s, a.p50_s, a.p75_s, a.p90_s, a.p95_s, a.p99_s, a.max_s, a.avg_s, a.std_s FROM query_distribution a LEFT JOIN pg_user u ON a.userid = u.usesysid ORDER BY 1, 2, 3, 4

--- a/core/sql/query_metrics.sql
+++ b/core/sql/query_metrics.sql
@@ -5,7 +5,7 @@ CREATE TEMP TABLE query_metrics AS (
          , date_trunc('hour', q.start_time)                                                as "period"
          , q.transaction_id                                                                as "xid"
          , q.query_id                                                                      as "query"
-         , q.query_text::char(50)                                                          as "querytxt"
+         , q.query_text::varchar(50)                                                       as "querytxt"
          , q.queue_time / 1000000.00                                                       as "queue_s"
          , q.execution_time / 1000000.00                                                   as "exec_time_s"     -- This includes compile time. Differs in behavior from provisioned metric
          , case when q.status = 'failed' then 1 else 0 end                                    "aborted"

--- a/core/tests/test_report_gen.py
+++ b/core/tests/test_report_gen.py
@@ -495,6 +495,39 @@ class TestReportGen(unittest.TestCase):
                     self.replay,
                 )
 
+    @patch("os.path.splitext", return_value=["query_name"])
+    @patch("os.listdir", return_value=["1.sql"])
+    @patch("core.replay.report_gen.initiate_connection")
+    def test_unload_multi_statement_setup(self, mock_init_conn, mock_listdir, mock_splitext):
+        # A setup block with two ;-separated CREATE TEMP TABLE statements should
+        # execute each statement, then UNLOAD the final block.
+        mock_cursor = MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+        mock_init_conn.return_value.__enter__.return_value = mock_connection
+        setup = (
+            "CREATE TEMP TABLE a AS SELECT 1;\n"
+            "CREATE TEMP TABLE b AS SELECT 2 WHERE 1 > {{START_TIME}} AND 1 < {{END_TIME}};"
+            "\n\nSELECT * FROM b"
+        )
+        mocked_open = mock_open(read_data=setup)
+        with patch("builtins.open", mocked_open):
+            report_gen.unload(
+                {"bucket_name": "b", "prefix": "p", "url": "someloc"},
+                "somerole",
+                self.provisioned_cluster,
+                self.user,
+                self.replay,
+            )
+        executed = [c.args[0] for c in mock_cursor.execute.call_args_list]
+        self.assertTrue(any(s.strip().startswith("CREATE TEMP TABLE a") for s in executed))
+        self.assertTrue(any(s.strip().startswith("CREATE TEMP TABLE b") for s in executed))
+        self.assertTrue(any(s.strip().startswith("unload (") for s in executed))
+        # The UNLOADed statement must be the final SELECT, not a setup statement.
+        unload_stmt = next(s for s in executed if s.strip().startswith("unload ("))
+        self.assertIn("SELECT * FROM b", unload_stmt)
+        self.assertNotIn("CREATE TEMP TABLE", unload_stmt)
+
     def test_read_data_empty_df(self):
         with self.assertRaises(SystemExit):
             report_gen.read_data("sometable", pandas.DataFrame(), [], self.report)


### PR DESCRIPTION
## Problem

The replay-analysis phase can abort with error 8001 ("Only ASCII characters are allowed in fixed length strings") when replayed queries contain non-ASCII characters (for example an em-dash or a non-breaking space) in `query_text`. This causes `make replay` to exit with Error 255 during report generation.

The error occurs when `query_text` is placed into a fixed-length `CHAR` column during analysis.

## Fix

Keep `query_text` out of any fixed-length `CHAR` context:

- **`aborted_queries.sql`, `query_metrics.sql`** (`querytxt` is in the output): cast the preview to `varchar(50)` instead of `char(50)`.
- **`cluster_level_metrics.sql`** (`querytxt` unused): drop the unused preview column.
- **`query_distribution.sql`, `latency_distribution.sql`**: pre-stage the replay rows into temp tables (numeric columns only) with a plain `LIKE` filter, then run the analysis over the staged tables, so `query_text` is never carried into the UNLOADed statement.
- **`core/replay/report_gen.py`** (`unload()`): execute each `;`-separated setup statement, so a staging block can create more than one temp table before the UNLOAD. Backward compatible with single-statement setups.

## No change needed

- `statement_types.sql`, `sys_query_history.sql`, `sys_load_history.sql`, `sys_external_query_data.sql` — these read `query_text` through the text path, which accepts non-ASCII.

## Testing

- `core/tests/test_report_gen.py` passes, including a new test (`test_unload_multi_statement_setup`) covering the multi-statement staging path and confirming the UNLOADed statement is the final SELECT (no `query_text`).
- Verified `latency_distribution.sql` and `query_distribution.sql` each split into the setup block and the final UNLOAD block, with no `query_text` in the UNLOADed statement.
