### PR TITLE
fix: Prevent replay analysis crash on non-UTF-8 query text

### DIFF
--- a/core/replay/report_gen.py
+++ b/core/replay/report_gen.py
@@ -429,7 +429,9 @@ def get_raw_data(report, bucket, replay_path, query):
     except Exception as e:
         logger.error(f"Unable to get raw data from S3. Results for {query} not found. {e}")
         exit(-1)
-    df = pd.read_csv(response.get("Body")).fillna(0)
+    # UNLOAD preserves bytes, so query_text may be non-UTF-8 (e.g. latin-1);
+    # decode tolerantly so the read-back does not crash.
+    df = pd.read_csv(response.get("Body"), encoding_errors="replace").fillna(0)
     logger.debug(f"Parsing results from '{query}' query.")
     if query == "latency_distribution":
         report.feature_graph = df

--- a/tools/ReplayAnalysis/api/app.py
+++ b/tools/ReplayAnalysis/api/app.py
@@ -56,7 +56,7 @@ def request_s3_data(filename, should_error_if_missing):
                 Bucket=replay["bucket"],
                 Key=f"{replay['s3_prefix']}raw_data/{filename}",
             )
-            temp = pd.read_csv(response.get("Body")).fillna(0)
+            temp = pd.read_csv(response.get("Body"), encoding_errors="replace").fillna(0)
         except Exception as e:
             if should_error_if_missing:
                 print(
@@ -445,7 +445,7 @@ def err_distribution():
         except Exception as e:
             continue
         try:
-            df = pd.read_csv(response.get("Body")).fillna(0)
+            df = pd.read_csv(response.get("Body"), encoding_errors="replace").fillna(0)
         except EmptyDataError:
             df = pd.DataFrame()
 


### PR DESCRIPTION
**Summary**

query_text can contain non-UTF-8 bytes, which UNLOAD writes to the CSV as-is. Reading those files with pandas' default strict UTF-8 aborts the analysis. Pass encoding_errors="replace" so invalid bytes are replaced instead of crashing.

*Description of changes:*

- core/replay/report_gen.py: get_raw_data()
- tools/ReplayAnalysis/api/app.py: request_s3_data(), err_distribution()


**Acknowledgment**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
