### PR TITLE
fix: Prevent duplicate Parquet column in NodeConfigCompare stats UNLOAD

### DIFF
--- a/tools/NodeConfigCompare/sql/gather_comparison_stats.sql
+++ b/tools/NodeConfigCompare/sql/gather_comparison_stats.sql
@@ -248,6 +248,25 @@ with no schema binding;
 
 
 unload ($$
-select * from public.redshift_detailed_query_stats where starttime > to_timestamp('{what_if_timestamp}','YYYY-MM-DD-HH24-MI-SS')
+select queue,
+       username,
+       cc_scaling,
+       aborted,
+       queue_time,
+       compile_time,
+       exec_time,
+       total_query_time,
+       userid,
+       query,
+       query_label,
+       xid,
+       pid,
+       service_class,
+       starttime,
+       endtime,
+       tables_scanned,
+       querytxt,
+       query_hash
+from public.redshift_detailed_query_stats where starttime > to_timestamp('{what_if_timestamp}','YYYY-MM-DD-HH24-MI-SS')
 $$) to '{comparison_stats_s3_path}/{what_if_timestamp}/{cluster_identifier}/'
 FORMAT AS PARQUET ALLOWOVERWRITE iam_role '{redshift_iam_role}';

--- a/tools/NodeConfigCompare/sql/gather_comparison_stats_serverless.sql
+++ b/tools/NodeConfigCompare/sql/gather_comparison_stats_serverless.sql
@@ -1,7 +1,23 @@
 unload ($$
-select a.*,Trim(u.usename) as username from sys_query_history a , pg_user u
-where a.user_id = u.usesysid
-and a.start_time > to_timestamp('{what_if_timestamp}','YYYY-MM-DD-HH24-MI-SS')
+select a.user_id,
+       a.query_id,
+       a.query_label,
+       a.transaction_id,
+       a.session_id,
+       a.database_name,
+       a.status,
+       a.result_cache_hit,
+       a.start_time,
+       a.end_time,
+       a.elapsed_time,
+       a.queue_time,
+       a.execution_time,
+       a.error_message,
+       a.query_text,
+       trim(u.usename) as username
+from sys_query_history a
+join pg_user u on a.user_id = u.usesysid
+where a.start_time > to_timestamp('{what_if_timestamp}','YYYY-MM-DD-HH24-MI-SS')
 $$) to '{comparison_stats_s3_path}/{what_if_timestamp}/{cluster_identifier}/'
 FORMAT AS PARQUET ALLOWOVERWRITE iam_role '{redshift_iam_role}';
 


### PR DESCRIPTION
## Summary

After a NodeConfigCompare run, the comparison views (`redshift_config_comparison_results`, `_raw`, `_aggregate`, and `redshift_config_comparison.comparison_stats`) fail with error 53002 "Duplicate Parquet column names in the schema", blocking the results-analysis step. This reproduces on node types whose Redshift build exposes a native `username` column in `sys_query_history`.


## Fix

Avoid duplicate/ambiguous output columns by selecting explicit column lists instead of `*`:

- `gather_comparison_stats_serverless.sql`: select an explicit column list from `sys_query_history` with a single `username` derived from `pg_user` (no `a.*`; build-agnostic).
- `gather_comparison_stats.sql`: unload the view's explicit columns instead of `select *`, so the Parquet schema is deterministic.


*Issue #, if available:* 
#187 

## Testing

- Confirmed `sys_query_history` exposes a native `username` on current builds (the collision condition).
- Reproduced the duplicate with the old shape (`CREATE TABLE AS SELECT a.*, ... username` → "column name \"username\" is duplicated") and verified the new explicit-column shape creates cleanly.
- Ran both UNLOADs to S3 as Parquet and confirmed the fixed output unloads and reads back without error.


## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
